### PR TITLE
Set teamengine.version and docker.teamengine.version to v5.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,15 @@
   <properties>
     <ets-code>ogcapi-tiles-1.0</ets-code>
     <spec-version>0.1</spec-version>
-    <docker.teamengine.version>5.4</docker.teamengine.version>
+    <teamengine.version>5.5.2</teamengine.version>
+    <docker.teamengine.version>5.5.2</docker.teamengine.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.opengis.cite.teamengine</groupId>
       <artifactId>teamengine-spi</artifactId>
+      <version>${teamengine.version}</version>
     </dependency>
     <dependency>
       <groupId>org.opengis.cite</groupId>


### PR DESCRIPTION
Updates the test suite to current TEAM Engine release.