### PR TITLE
Introduce "generateHtmlReport" flag to allow user to get HTML output

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapitiles10/CommandLineArguments.java
+++ b/src/main/java/org/opengis/cite/ogcapitiles10/CommandLineArguments.java
@@ -35,6 +35,9 @@ public class CommandLineArguments {
 			description = "Delete file containing representation of test subject when finished")
 	private boolean deleteSubjectOnFinish = false;
 
+	@Parameter(names = {"-h", "--generateHtmlReport"}, arity = 1, description = "Enable HTML report generation")
+	private boolean generateHtmlReport = false;
+
 	public CommandLineArguments() {
 		this.xmlProps = new ArrayList<>();
 	}
@@ -59,4 +62,7 @@ public class CommandLineArguments {
 		return deleteSubjectOnFinish;
 	}
 
+	public boolean isGenerateHtmlReport() {
+		return generateHtmlReport;
+	}
 }

--- a/src/main/java/org/opengis/cite/ogcapitiles10/TestNGController.java
+++ b/src/main/java/org/opengis/cite/ogcapitiles10/TestNGController.java
@@ -41,13 +41,14 @@ public class TestNGController implements TestSuiteController {
 	 * <li>XML properties file: ${user.home}/test-run-props.xml</li>
 	 * <li>outputDir: ${user.home}</li>
 	 * <li>deleteSubjectOnFinish: false</li>
+	 * <li>generateHtmlReport: false</li>
 	 * </ul>
 	 * <p>
 	 * <strong>Synopsis</strong>
 	 * </p>
 	 *
 	 * <pre>
-	 * ets-*-aio.jar [-o|--outputDir $TMPDIR] [-d|--deleteSubjectOnFinish] [test-run-props.xml]
+	 * ets-*-aio.jar [-o|--outputDir $TMPDIR] [-d|--deleteSubjectOnFinish] [-h|--generateHtmlReport] [test-run-props.xml]
 	 * </pre>
 	 * @param args Test run arguments (optional). The first argument must refer to an XML
 	 * properties file containing the expected set of test run arguments. If no argument
@@ -72,7 +73,7 @@ public class TestNGController implements TestSuiteController {
 		DocumentBuilder db = dbf.newDocumentBuilder();
 		File xmlArgs = testRunArgs.getPropertiesFile();
 		Document testRunProps = db.parse(xmlArgs);
-		TestNGController controller = new TestNGController(testRunArgs.getOutputDir());
+		TestNGController controller = new TestNGController(testRunArgs.getOutputDir(), testRunArgs.isGenerateHtmlReport());
 		Source testResults = controller.doTestRun(testRunProps);
 		System.out.println("Test results: " + testResults.getSystemId());
 	}
@@ -82,16 +83,20 @@ public class TestNGController implements TestSuiteController {
 	 * as the root output directory.
 	 */
 	public TestNGController() {
-		this(System.getProperty("java.io.tmpdir"));
+		this(System.getProperty("java.io.tmpdir"), false);
 	}
 
 	/**
 	 * Construct a controller that writes results to the given output directory.
-	 * @param outputDir The location of the directory in which test results will be
-	 * written (a file system path or a 'file' URI). It will be created if it does not
-	 * exist.
+	 *
+	 * @param outputDir
+	 *            The location of the directory in which test results will be
+	 *            written (a file system path or a 'file' URI). It will be
+	 *            created if it does not exist.
+	 * @param generateHtmlReport
+	 *            Enable HTML report generation.
 	 */
-	public TestNGController(String outputDir) {
+	public TestNGController(String outputDir, boolean generateHtmlReport) {
 		InputStream is = getClass().getResourceAsStream("ets.properties");
 		try {
 			this.etsProperties.load(is);
@@ -113,7 +118,7 @@ public class TestNGController implements TestSuiteController {
 		TestSuiteLogger.log(Level.CONFIG, "Using TestNG config: " + tngSuite);
 		TestSuiteLogger.log(Level.CONFIG, "Using outputDirPath: " + resultsDir.getAbsolutePath());
 		// NOTE: setting third argument to 'true' enables the default listeners
-		this.executor = new TestNGExecutor(tngSuite.toString(), resultsDir.getAbsolutePath(), false);
+		this.executor = new TestNGExecutor(tngSuite.toString(), resultsDir.getAbsolutePath(), generateHtmlReport);
 	}
 
 	@Override


### PR DESCRIPTION
Aligning with https://github.com/opengeospatial/ets-ogcapi-features10, introduces a `generateHtmlReport` CLI flag to get HTML + JUnit XML output in addition to TestNG XML output.