### PR TITLE
Allow HTTP 204 on tile within tileMatrixSet limits

### DIFF
--- a/src/main/java/org/opengis/cite/ogcapitiles10/conformance/Tile.java
+++ b/src/main/java/org/opengis/cite/ogcapitiles10/conformance/Tile.java
@@ -551,9 +551,9 @@ public class Tile extends CommonFixture {
 
 								int responseCode = httpConn.getResponseCode();
 
-								if (responseCode != 200) {
+								if (responseCode != 200 && responseCode != 204) {
 									errorMessages
-											.append("Expected status code 200 but received " + responseCode + " . ");
+											.append("Expected status code 200 or 204 but received " + responseCode + " . ");
 								}
 							}
 							else if (checkErrorResponse == true) {


### PR DESCRIPTION
As per Requirement 6B: When a requested tile - that is within the configured tile matrix set limits of the resource - has no content, the allowed HTTP response status codes are either 204 or 200. The current test only allows 200.